### PR TITLE
Use upstream redmine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM sameersbn/redmine:3.4.13
+FROM redmine:3.4.13
 
-# Install DMSF plugin dependencies
+# Build and install DMSF plugin dependencies
 # https://github.com/danmunn/redmine_dmsf#dependencies
 RUN set -ex; \
 	\
@@ -11,11 +11,12 @@ RUN set -ex; \
 		catdvi \
 		djview \
 		djview3 \
+		gcc \
 		gzip \
 		libwpd-0.10-10 \
 		libwps-0.4-4 \
 		libxapian-dev \
-		ruby-xapian \
+		make \
 		unrtf \
 		unzip \
 		uuid \


### PR DESCRIPTION
The upstream image is smaller, better maintained and uses a Debian base image whereas `sameersbn/redmine` is based on a outdated Ubuntu.

Note: this requires some changes here
https://github.com/ppschweiz/pps-infra/blob/a7d0abc23bce146ecd756614df844a8e58a41c8e/ansible/container-projects.yaml#L29-L41

Mail need to be configured in a mounted config file, web server variables are not needed.
See https://hub.docker.com/_/redmine#environment-variables